### PR TITLE
Add `all` option to show more details in a run

### DIFF
--- a/github-ls
+++ b/github-ls
@@ -97,6 +97,13 @@ OptionParser.new do |opts|
       ...
   ENDOFUSAGE
 
+  opts.on('--all', 'enable most things. Including archived repos, forks and long output.',
+          '') do |v|
+    options[:archived]    = v
+    options[:forked]      = v
+    options[:long_format] = v
+  end
+
   opts.on('-a', '--archived',
           'include archived repositories in the output.') { |v| options[:archived] = v }
 


### PR DESCRIPTION
"enable most things. Including archived repos, forks and long output."
This is the flag to use if you're not looking for something specific