### PR TITLE
Add the ability to display the hash of GitHub files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ for a repository.
 
     bundle exec ./github-ls deanwilson --with-file /.rubocop.yml
 
+When using `--with-file` you can also specify `--hash` to display a
+sha256 hash of the content in the output. This can help find repository
+repositories that have inconsistent versions of a file.
+
+    bundle exec ./github-ls deanwilson --with-file /.rubocop.yml --hash --long --all
+    A - 	 2019-10-16T08:58:26Z 	 0 	 deanwilson/puppet-liquidtemplates ae2b3d2760e4287a
+    - - 	 2020-06-22T09:54:55Z 	 1 	 deanwilson/puppet-multi_epp c9029c39d69e42f5688afa
+
 
 ### Author
 

--- a/github-ls
+++ b/github-ls
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require 'base64'
+require 'digest'
 require 'github_api'
 require 'optparse'
 
@@ -6,7 +8,7 @@ def display_repos(options, repos)
   # the routing function for different output modes
 
   if options[:long_format]
-    display_repos_long(repos)
+    display_repos_long(options, repos)
   else
     display_repos_short(options, repos)
   end
@@ -15,16 +17,24 @@ def display_repos(options, repos)
 end
 
 def display_repos_short(options, repos)
-  names = repos.map { |r| r.name }
+  repos.each do |repo|
+    name = []
 
-  names = repos.map { |r| "#{options[:user]}/#{r.name}" } if options[:long_names]
+    if options[:long_names]
+      name << repo.full_name
+    else
+      name << repo.name
+    end
 
-  names.each do |name|
-    puts name
+    if options[:with_file] and options[:show_hash]
+      name << repo['github_ls_hash']
+    end
+
+    puts name.join(' ')
   end
 end
 
-def display_repos_long(repos)
+def display_repos_long(options, repos)
   expanded_repos = []
 
   repos.each do |repo|
@@ -41,6 +51,10 @@ def display_repos_long(repos)
 
     expanded << repo.full_name
 
+    if options[:with_file] and options[:show_hash]
+      expanded << repo['github_ls_hash']
+    end
+
     expanded_repos << expanded
   end
 
@@ -55,6 +69,7 @@ def repo_file_check(repos, github, options)
 
   file_present = []
   file_absent  = []
+  file_shas    = {} # repo => sha
 
   repos.each do |repo|
     github_file = nil
@@ -64,10 +79,16 @@ def repo_file_check(repos, github, options)
       file_absent << repo
     else
       file_present << repo
+      # puts "File contents for #{repo.name} == #{github_file[:content]}"
+
+      decoded = Base64.decode64(github_file[:content])
+      content_sha = Digest::SHA256.hexdigest decoded
+
+      repo['github_ls_hash'] = content_sha
     end
   end
 
-  { 'present': file_present, 'absent': file_absent }
+  { 'present': file_present, 'absent': file_absent, 'hashes': file_shas }
 end
 
 APP_NAME = File.basename $PROGRAM_NAME
@@ -79,6 +100,7 @@ options = {
   long_names:    false,
   only_archived: false,
   only_forked:   false,
+  show_hash:     false,
   url_type:      false,
   with_file:     false,
   without_file:  false,
@@ -109,6 +131,8 @@ OptionParser.new do |opts|
 
   opts.on('-f', '--fork',
           'include forked repositories in the output.') { |v| options[:forked] = v }
+
+  opts.on('--hash', 'show SHA256 hash of the files contents') { |v| options[:show_hash] = v }
 
   opts.on('--long',
           'display more details about each repository') { |v| options[:long_format] = v }


### PR DESCRIPTION
This provides a way to list all of a given file, such as a saas config
or developer tool, and a hash of the contents to make spotting
deviation easier.